### PR TITLE
Solve NameError: name '[user input]' is not defined in Python2

### DIFF
--- a/send.py
+++ b/send.py
@@ -1,3 +1,4 @@
+import sys
 import pyaudio
 import quietnet
 import options
@@ -13,6 +14,9 @@ DATASIZE = options.datasize
 
 p = pyaudio.PyAudio()
 stream = p.open(format=FORMAT, channels=CHANNELS, rate=RATE, output=True)
+
+user_input = input if sys.version_info.major >= 3 else raw_input
+
 
 def make_buffer_from_bit_pattern(pattern, on_freq, off_freq):
     """ Takes a pattern and returns an audio buffer that encodes that pattern """
@@ -48,7 +52,7 @@ if __name__ == "__main__":
     try:
         # get user input and play message
         while True:
-            message = input("> ")
+            message = user_input("> ")
             try:
               pattern = psk.encode(message)
               buffer = make_buffer_from_bit_pattern(pattern, FREQ, FREQ_OFF)


### PR DESCRIPTION
``` sh
$ python2 send.py
Welcome to quietnet. Use ctrl-c to exit
> hello
Traceback (most recent call last):
  File "send.py", line 51, in <module>
    message = input("> ")
  File "<string>", line 1, in <module>
NameError: name 'hello' is not defined
```

This problem is caused by the difference of builtin function `input` between Python3 and Python2.
- In Python2 `input()` is equivalent to `eval(raw_input())`
- In Python3 `raw_input()` is renamed to `input()`

This patch should make `send.py` work on both Python2 and Python3.
